### PR TITLE
Revise README for 2026 ESICM Datathon

### DIFF
--- a/datathons/2026-01-esicm-datathon-colab/README.md
+++ b/datathons/2026-01-esicm-datathon-colab/README.md
@@ -1,1 +1,36 @@
-- Will soon be updated -
+## <img src="https://github.com/AmsterdamUMC/AmsterdamUMCdb/blob/master/img/logo_esicm_datathon_2025.jpg?raw=1" alt="Logo Datathon" width=128px/>
+<img src="https://github.com/AmsterdamUMC/AmsterdamUMCdb/blob/master/img/logo_c4i_square.png?raw=1" alt="Logo C4I" width=128px/><img src="https://github.com/AmsterdamUMC/AmsterdamUMCdb/blob/master/img/logo_amds.png?raw=1" alt="Logo AMDS" width=128px/>
+
+# 8th ESICM Critical Care Datathon 2026
+## AmsterdamUMCdb - Freely Accessible ICU Database
+
+version Van Gogh 2026.01  
+Copyright &copy; 2003-2026 Amsterdam UMC - Amsterdam Medical Data Science
+
+## Introduction
+
+To make the most of your time during the datathon, access to AmsterdamUMCdb will be provided using Google BigQuery using
+Google Colaboratory as the main coding environment. This removes the necessity to download AmsterdamUMCdb, setting up a
+database system and installing a coding environment. 
+
+To improve reusability of the data and code, AmsterdamUMCdb will be made available in the OMOP Common Data Model format. To get a head start, you may want to have a look [here](https://www.ohdsi.org/data-standardization/).
+
+## Running Colab
+
+Open Colab with the *AmsterdamUMCdb with Google BigQuery and Colaboratory* **getting_started** notebook from the official AmsterdamUMCdb GitHub
+repository: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/AmsterdamUMC/AmsterdamUMCdb/blob/master/bigquery/getting_started.ipynb)
+
+## The challenges
+
+### Track 1 - 
+Will be revealed durting the kick-off
+
+### Track 2 - 
+Will be revealed durting the kick-off
+
+
+## Troubleshooting
+
+If you run into any problem related to accessing AmsterdamUMCdb on Google BigQuery, please have a look at
+the [Frequently Asked Questions](https://github.com/AmsterdamUMC/AmsterdamUMCdb/wiki/bigquery#faq) on
+the [AmsterdamUMCdb wiki](https://github.com/AmsterdamUMC/AmsterdamUMCdb/wiki). 


### PR DESCRIPTION
Updated README.md for the 8th ESICM Critical Care Datathon 2026 with logos, introduction, and troubleshooting information.